### PR TITLE
Unified hyperswarm cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyperswarm CLI
 
-A series of CLI tools to debug and interact with the Hyperswarm network
+A series of CLI tools to debug and interact with the Hyperswarm network.
 
 ```sh
 npm install -g @hyperswarm/cli
@@ -8,14 +8,8 @@ npm install -g @hyperswarm/cli
 
 ## Usage
 
-This currently installs 2 tools
-
 ```sh
-# Interact with the discovery network (DHT and MDNS)
-hyperswarm-discovery # will print help
-
-# Use the discovery to make connections
-hyperswarm-swarm # will print help
+hyperswarm # will print help
 ```
 
 ## License

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const cmd = process.argv[1]
+const op = process.argv[2]
+if (!['discovery', 'swarm'].includes(op)) {
+  console.error(`Usage: ${cmd} [command] --help
+
+  Commands:
+  
+    discovery ... Interact with the discovery network (DHT and MDNS)
+    swarm ....... Use the discovery to make connections
+
+  Example:
+
+    hyperswarm discovery --help
+`)
+  process.exit(1)
+}
+const path = require('path')
+const file = path.join(__dirname, `${op}.js`)
+
+process.argv = [process.argv[0], `${cmd} ${op}`].concat(process.argv.slice(3))
+require(file)

--- a/discovery.js
+++ b/discovery.js
@@ -27,7 +27,7 @@ const argv = minimist(process.argv, {
 })
 
 if (!argv.ping && !argv.announce && !argv.unannounce && !argv.lookup && !argv['find-node']) {
-  console.error(`Usage: hyperswarm-discovery [options]
+  console.error(`Usage: ${process.argv[1]} [options]
 
   --announce, -a     [key]
   --unannounce, -u   [key]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "CLI tool to interact with Hyperswarm",
   "bin": {
+    "hyperswarm": "./bin.js",
     "hyperswarm-discovery": "./discovery.js",
     "hyperswarm-swarm": "./swarm.js"
   },

--- a/swarm.js
+++ b/swarm.js
@@ -18,7 +18,7 @@ const argv = minimist(process.argv, {
 })
 
 if (!argv.lookup && !argv.announce) {
-  console.error(`Usage: hyperswarm-swarm [options]
+  console.error(`Usage: ${process.argv[1]} [options]
 
   --announce, -a
   --lookup, -l


### PR DESCRIPTION
This PR adds a unified hyperswarm executable that can be used instead of and additionally to the long-form commands.

e.g. `hyperswarm-swarm --help` can also be executed as `hyperswarm swarm --help`

Closes #1 