### PR TITLE
Adding DHT command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hyperswarm CLI
 
-A series of CLI tools to debug and interact with the Hyperswarm network
+A series of CLI tools to debug and interact with the Hyperswarm network.
 
 ```sh
 npm install -g @hyperswarm/cli
@@ -8,14 +8,8 @@ npm install -g @hyperswarm/cli
 
 ## Usage
 
-This currently installs 2 tools
-
 ```sh
-# Interact with the discovery network (DHT and MDNS)
-hyperswarm-discovery # will print help
-
-# Use the discovery to make connections
-hyperswarm-swarm # will print help
+hyperswarm # will print help
 ```
 
 ## License

--- a/bin.js
+++ b/bin.js
@@ -2,13 +2,14 @@
 
 const cmd = process.argv[1]
 const op = process.argv[2]
-if (!['discovery', 'swarm'].includes(op)) {
+if (!['discovery', 'swarm', 'dht'].includes(op)) {
   console.error(`Usage: ${cmd} [command] --help
 
   Commands:
   
     discovery ... Interact with the discovery network (DHT and MDNS)
     swarm ....... Use the discovery to make connections
+    dht ......... Start a dht node
 
   Example:
 

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const cmd = process.argv[1]
+const op = process.argv[2]
+if (!['discovery', 'swarm'].includes(op)) {
+  console.error(`Usage: ${cmd} [command] --help
+
+  Commands:
+  
+    discovery ... Interact with the discovery network (DHT and MDNS)
+    swarm ....... Use the discovery to make connections
+
+  Example:
+
+    hyperswarm discovery --help
+`)
+  process.exit(1)
+}
+const path = require('path')
+const file = path.join(__dirname, `${op}.js`)
+
+process.argv = [process.argv[0], `${cmd} ${op}`].concat(process.argv.slice(3))
+require(file)

--- a/dht.js
+++ b/dht.js
@@ -61,7 +61,7 @@ const dht = createDht({ ephemeral, adaptive: ephemeral, id: id.id, bootstrap })
 
 log(
   ({ start }) => `Starting Node:
-${util.inspect(start, { colors: true }).padStart(4)}
+${util.inspect(start, { colors: true })}
 `,
   {
     start: {

--- a/dht.js
+++ b/dht.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+const createDht = require('@hyperswarm/dht')
+const minimist = require('minimist')
+const os = require('os')
+const path = require('path')
+const fs = require('fs')
+const dhtrpc = require('dht-rpc')
+const util = require('util')
+
+const argv = minimist(process.argv, {
+  boolean: [
+    'ephemeral',
+    'quiet',
+    'help',
+    'json'
+  ],
+  string: [
+    'address',
+    'id-file',
+    'id'
+  ],
+  default: {
+    ephemeral: true,
+    'id-file': 'dht-rpc-id',
+    quiet: false
+  },
+  alias: {
+    ephemeral: 'e',
+    bootstrap: 'b',
+    quiet: 'q',
+    address: 'a',
+    port: 'p',
+    'id-file': 'f',
+    id: 'i',
+    help: 'h',
+    json: 'j'
+  }
+})
+
+if (argv.help) {
+  console.error(`Usage: ${process.argv[1]} [options]
+  --id, -i           [key]   ID for this dht node
+  --id-file, -f      [path]  Path to store a random id for this node (ignored if id is given)
+  --port, -p         [port]  Specify port to listen to (optional, as dht-nodes don't require listening)
+  --address, -a      [addr]  Specify address to listen to (optional, only used if port is given)
+  --json                     Output all messages as json.
+  --quiet, -q                Hide announce output
+  --no-ephemeral             Host other peoples keys/values
+  --bootstrap, -b            Specify bootstrap peers (optional)
+`)
+  process.exit(1)
+}
+
+const id = resolveId(argv.id, argv['id-file'])
+const ephemeral = argv.ephemeral
+const port = argv.port || process.env.PORT
+const bootstrap = argv.boostrap ? [].concat(argv.bootstrap || []) : undefined
+let exitCode = 0
+const dht = createDht({ ephemeral, adaptive: ephemeral, id: id.id, bootstrap })
+
+log(
+  ({ start }) => `Starting Node:
+${util.inspect(start, { colors: true }).padStart(4)}
+`,
+  {
+    start: {
+      nodejsVersion: process.version,
+      cliVersion: require('./package.json').version,
+      dhtVersion: require('@hyperswarm/dht/package.json').version,
+      node: {
+        ...id,
+        id: dht.id.toString('hex')
+      },
+      port: port || undefined,
+      address: argv.address || undefined,
+      bootstrap,
+      ephemeral,
+      quiet: argv.quiet
+    }
+  }
+)
+
+dht.on('listening', function () {
+  log(({ listening: { address, port, family } }) => `Listening to ${address}:${port} (udp,${family})`, { listening: this.socket.address() })
+})
+dht.on('ready', function () {
+  log(() => 'DHT node fully bootstrapped.', { state: 'bootstrapped' })
+})
+dht.on('persistent', function () {
+  log(() => 'DHT is now persistent', { state: 'persitent' })
+})
+dht.on('warning', function (warning) {
+  log(() => `Warning: ${warning.message}`, { warning })
+})
+dht.on('error', function (error) {
+  log(() => `Error: ${error.message}`, { error })
+  exitCode = 1
+  close()
+})
+dht.on('close', function () {
+  log(() => 'DHT node fully closed.', { state: 'closed' })
+  process.exit(exitCode)
+})
+if (port) {
+  dht.listen(port, argv.address)
+}
+
+if (!argv.quiet) {
+  for (const event of ['announce', 'unannounce', 'lookup']) {
+    dht.on(event, function (target, peer) {
+      log(({ target, peer }) => `Received ${event}:\n${util.inspect({ target: target.toString('hex'), peer }, { colors: true })}`, { event, target, peer })
+    })
+  }
+}
+
+process.on('SIGINT', close)
+
+function close () {
+  log(() => '\nClosing DHT Node.', { state: 'closing' })
+  dht.destroy()
+}
+
+function log (toString, obj) {
+  if (argv.json) {
+    console.log(JSON.stringify(obj))
+  } else {
+    console.log(toString(obj))
+  }
+}
+
+function resolveId (id, idFile) {
+  if (id !== undefined) {
+    // Skip writing the id to disc as passing in the id is supposed to increase the startup speed.
+    return { id: Buffer.from(id, 'hex'), method: 'argv' }
+  }
+  // Allowing temporary files as relative paths but also supporting absolute paths.
+  idFile = path.resolve(os.tmpdir(), idFile)
+  let rndId
+  if (!fs.existsSync(idFile)) {
+    rndId = dhtrpc.id().slice(0, 32)
+    fs.writeFileSync(idFile, rndId)
+  }
+  id = fs.readFileSync(idFile).slice(0, 32)
+  return {
+    id,
+    method: rndId && rndId.equals(id) ? 'rnd' : 'fs',
+    store: idFile
+  }
+}

--- a/discovery.js
+++ b/discovery.js
@@ -27,7 +27,7 @@ const argv = minimist(process.argv, {
 })
 
 if (!argv.ping && !argv.announce && !argv.unannounce && !argv.lookup && !argv['find-node']) {
-  console.error(`Usage: hyperswarm-discovery [options]
+  console.error(`Usage: ${process.argv[1]} [options]
 
   --announce, -a     [key]
   --unannounce, -u   [key]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": {
     "hyperswarm": "./bin.js",
     "hyperswarm-discovery": "./discovery.js",
-    "hyperswarm-swarm": "./swarm.js"
+    "hyperswarm-swarm": "./swarm.js",
+    "hyperswarm-dht": "./dht.js"
   },
   "dependencies": {
     "@hyperswarm/discovery": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "CLI tool to interact with Hyperswarm",
   "bin": {
+    "hyperswarm": "./bin.js",
     "hyperswarm-discovery": "./discovery.js",
     "hyperswarm-swarm": "./swarm.js"
   },

--- a/swarm.js
+++ b/swarm.js
@@ -18,7 +18,7 @@ const argv = minimist(process.argv, {
 })
 
 if (!argv.lookup && !argv.announce) {
-  console.error(`Usage: hyperswarm-swarm [options]
+  console.error(`Usage: ${process.argv[1]} [options]
 
   --announce, -a
   --lookup, -l


### PR DESCRIPTION
Based on #3 (← merge this first)

This PR adds a `hyperswarm dht` command that allows the starting of a dht node.
This is based on code from [@hyperswarm/dht](https://github.com/hyperswarm/cli/compare/master...martinheidegger:dht?expand=1#diff-071aca63fa98468327db15103fc42a0cR58) but extends it in several aspects.

- Adding of a `--help` option to be conform with the other commands

    <img width="839" alt="Screen Shot 2020-04-19 at 20 46 46" src="https://user-images.githubusercontent.com/914122/79686944-eb191080-827e-11ea-9b7f-c971e21a2a90.png">


- Logging of options and environment information

    <img width="608" alt="Screen Shot 2020-04-19 at 20 44 32" src="https://user-images.githubusercontent.com/914122/79686896-a1c8c100-827e-11ea-9bb2-e8376c0ca77e.png">

- New `--port` and `--address` options to bind to an udp-port, that is also falling back to a `process.env.PORT` variable.

    <img width="611" alt="Screen Shot 2020-04-19 at 20 29 37" src="https://user-images.githubusercontent.com/914122/79686606-9eccd100-827c-11ea-9824-36b91c4c26cc.png">

- Closing of the dht-node on sigint:

     <img width="308" alt="Screen Shot 2020-04-19 at 20 40 08" src="https://user-images.githubusercontent.com/914122/79686798-fa4b8e80-827d-11ea-97cf-87390a967e65.png">

- or error

    <img width="298" alt="Screen Shot 2020-04-19 at 20 39 21" src="https://user-images.githubusercontent.com/914122/79686805-09cad780-827e-11ea-92a9-46dad952cdfb.png">


- New `--json` option that shows all log messages as json, useful for sys-ops folks.

     <img width="610" alt="Screen Shot 2020-04-19 at 20 30 15" src="https://user-images.githubusercontent.com/914122/79686613-b5732800-827c-11ea-9912-1f58f20ce79a.png">

- New `--id` option to speed-up startup process - as it skips the fs operations

     <img width="773" alt="Screen Shot 2020-04-19 at 20 42 39" src="https://user-images.githubusercontent.com/914122/79686862-5ca48f00-827e-11ea-8917-2130c866d08f.png">

- New `--id-file` option to allow placing the id file in a pre-specified location
- New `--bootstrap` option that works same as in `hyperswarm discovery`
- Formatting of announces with colors in cli mode:

    <img width="623" alt="Screen Shot 2020-04-19 at 20 55 42" src="https://user-images.githubusercontent.com/914122/79687148-341d9480-8280-11ea-948a-722c1d380b99.png">

