### PR TITLE
Upgrade dep

### DIFF
--- a/discovery.js
+++ b/discovery.js
@@ -3,12 +3,14 @@
 const discovery = require('@hyperswarm/discovery')
 const sodium = require('sodium-universal')
 const minimist = require('minimist')
+const estimate = require('dht-size-up')
 
 const argv = minimist(process.argv, {
   boolean: [
     'ephemeral',
     'ping',
-    'hash'
+    'hash',
+    'size'
   ],
   default: {
     ephemeral: true
@@ -25,7 +27,7 @@ const argv = minimist(process.argv, {
   }
 })
 
-if (!argv.ping && !argv.announce && !argv.unannounce && !argv.lookup && !argv['find-node']) {
+if (!argv.ping && !argv.announce && !argv.unannounce && !argv.lookup && !argv['find-node'] && !argv['estimate-dht-size']) {
   console.error(`Usage: ${process.argv[1]} [options]
 
   --announce, -a     [key]
@@ -36,6 +38,7 @@ if (!argv.ping && !argv.announce && !argv.unannounce && !argv.lookup && !argv['f
   --hash, -h                 Autohash the key
   --no-ephemeral             Host other peoples keys/values
   --bootstrap, -b            Specify bootstrap peers
+  --estimate-dht-size        Estimate number of nodes in DHT
 `)
   process.exit(1)
 }
@@ -85,6 +88,13 @@ if (argv.announce) {
     .on('peer', function (peer) {
       console.log(peer)
     })
+}
+
+if (argv['estimate-dht-size']) {
+  estimate(d.dht, function (err, size, n, q) {
+    if (err) console.error(err)
+    else console.log(`Sampled ${n} nodes over ${q} queries. Estimated DHT size is ${size}.`)
+  })
 }
 
 function key () {

--- a/discovery.js
+++ b/discovery.js
@@ -9,8 +9,7 @@ const argv = minimist(process.argv, {
   boolean: [
     'ephemeral',
     'ping',
-    'hash',
-    'size'
+    'hash'
   ],
   default: {
     ephemeral: true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hyperswarm/dht": "^3.6.2",
     "@hyperswarm/discovery": "^1.11.4",
+    "dht-size-up": "0.0.3",
     "hyperswarm": "^2.13.0",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@hyperswarm/dht": "^3.6.2",
     "@hyperswarm/discovery": "^1.11.4",
-    "dht-size-up": "0.0.3",
+    "dht-size-up": "0.0.4",
     "hyperswarm": "^2.13.0",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@hyperswarm/dht": "^3.6.2",
     "@hyperswarm/discovery": "^1.11.4",
-    "dht-size-up": "0.0.4",
+    "dht-size-up": "1.0.0",
     "hyperswarm": "^2.13.0",
     "minimist": "^1.2.5",
     "pump": "^3.0.0",


### PR DESCRIPTION
upgrade dht-size-up to v0.0.4 to return largest estimate of size.
prevents "Sampled 64 nodes over 20 queries. Estimated DHT size is 52." 